### PR TITLE
Day 4

### DIFF
--- a/src/bin/04.rs
+++ b/src/bin/04.rs
@@ -1,4 +1,5 @@
 use std::collections::HashSet;
+use std::cmp::{ max, min };
 
 fn main() {
     let input = helpers::read_file("inputs", 4);
@@ -6,43 +7,47 @@ fn main() {
     println!("Part 2: {}", part_two(&input));
 }
 
-pub fn part_one(input: &str) -> u32 {
-    let test = String::from("1-4,3-4");
-    let s = parse_pairs(&test);
-    println!("test: {:?}", s);
-    0
-}
-
-pub fn part_two(input: &str) -> u32 {
-    0
-}
-
-fn parse_pairs(input: &str) -> usize {
+pub fn part_one(input: &str) -> usize {
     input
         .lines()
         .map(|pair| {
-            let a = parse_pair(pair);
-            let elf1: HashSet<&u8> = a[0].iter().collect();
-            let elf2: HashSet<&u8> = a[1].iter().collect();
-            println!("elf1: {:?}, a0: {:?}", elf1, a[0]);
-            println!("elf2: {:?}, a1: {:?}", elf2, a[1]);
-            elf2.is_subset(&elf1)
+            let parsed_pairs = parse_pair(pair);
+
+            let elf1: HashSet<&u8> = parsed_pairs.0.iter().collect();
+            let elf2: HashSet<&u8> = parsed_pairs.1.iter().collect();
+
+            elf2.is_subset(&elf1) || elf1.is_subset(&elf2)
         })
-        .collect::<Vec<bool>>()
-        .into_iter()
-        .filter(|x| *x)
+        .filter(|x| *x == true)
         .count()
 }
 
-fn parse_pair(pair: &str) -> Vec<Vec<u8>> {
+pub fn part_two(input: &str) -> usize {
+    input
+        .lines()
+        .filter(|pair| {
+            let a = parse_pair(pair);
+            
+            max(a.0.first(), a.1.first()) <= 
+            min(a.0.last(), a.1.last())
+        })
+        .count()
+}
+
+fn parse_pair(pair: &str) -> (Vec<u8>, Vec<u8>) {
     pair
-        .split(",")
-        .map(|elf| parse_elf(elf))
-        .collect::<Vec<Vec<u8>>>()
+        .split_once(",")
+        .map(|(elf1, elf2)| (parse_elf(elf1), parse_elf(elf2)))
+        .unwrap()
 }
 
 fn parse_elf(elf: &str) -> Vec<u8> {
-    elf.split("-")
-        .map(|section| section.parse::<u8>().unwrap())
-        .collect::<Vec<u8>>()
+    elf.split_once("-")
+        .map(|(start, end)| {
+            (start.parse::<u8>().unwrap()
+            ..
+            end.parse::<u8>().unwrap() + 1)
+            .collect()
+        })
+        .unwrap()
 }

--- a/src/bin/04.rs
+++ b/src/bin/04.rs
@@ -1,0 +1,48 @@
+use std::collections::HashSet;
+
+fn main() {
+    let input = helpers::read_file("inputs", 4);
+    println!("Part 1: {}", part_one(&input));
+    println!("Part 2: {}", part_two(&input));
+}
+
+pub fn part_one(input: &str) -> u32 {
+    let test = String::from("1-4,3-4");
+    let s = parse_pairs(&test);
+    println!("test: {:?}", s);
+    0
+}
+
+pub fn part_two(input: &str) -> u32 {
+    0
+}
+
+fn parse_pairs(input: &str) -> usize {
+    input
+        .lines()
+        .map(|pair| {
+            let a = parse_pair(pair);
+            let elf1: HashSet<&u8> = a[0].iter().collect();
+            let elf2: HashSet<&u8> = a[1].iter().collect();
+            println!("elf1: {:?}, a0: {:?}", elf1, a[0]);
+            println!("elf2: {:?}, a1: {:?}", elf2, a[1]);
+            elf2.is_subset(&elf1)
+        })
+        .collect::<Vec<bool>>()
+        .into_iter()
+        .filter(|x| *x)
+        .count()
+}
+
+fn parse_pair(pair: &str) -> Vec<Vec<u8>> {
+    pair
+        .split(",")
+        .map(|elf| parse_elf(elf))
+        .collect::<Vec<Vec<u8>>>()
+}
+
+fn parse_elf(elf: &str) -> Vec<u8> {
+    elf.split("-")
+        .map(|section| section.parse::<u8>().unwrap())
+        .collect::<Vec<u8>>()
+}


### PR DESCRIPTION
Space needs to be cleared before the last supplies can be unloaded from the ships, and so several Elves have been assigned the job of cleaning up sections of the camp. Every section has a unique ID number, and each Elf is assigned a range of section IDs.

However, as some of the Elves compare their section assignments with each other, they've noticed that many of the assignments overlap. To try to quickly find overlaps and reduce duplicated effort, the Elves pair up and make a big list of the section assignments for each pair (your puzzle input).

For example, consider the following list of section assignment pairs:
```
2-4,6-8
2-3,4-5
5-7,7-9
2-8,3-7
6-6,4-6
2-6,4-8
```
For the first few pairs, this list means:

- Within the first pair of Elves, the first Elf was assigned sections ´2-4´ (sections 2, 3, and 4), while the second Elf was assigned sections ´6-8´ (sections 6, 7, 8).
 -The Elves in the second pair were each assigned two sections.
- The Elves in the third pair were each assigned three sections: one got sections 5, 6, and 7, while the other also got 7, plus 8 and 9.

This example list uses single-digit section IDs to make it easier to draw; your actual list might contain larger numbers. Visually, these pairs of section assignments look like this:
```
.234.....  2-4
.....678.  6-8

.23......  2-3
...45....  4-5

....567..  5-7
......789  7-9

.2345678.  2-8
..34567..  3-7

.....6...  6-6
...456...  4-6

.23456...  2-6
...45678.  4-8
```
Some of the pairs have noticed that one of their assignments fully contains the other. For example, ´2-8´ fully contains ´3-7´, and ´6-6´ is fully contained by ´4-6´. In pairs where one assignment fully contains the other, one Elf in the pair would be exclusively cleaning sections their partner will already be cleaning, so these seem like the most in need of reconsideration. In this example, there are 2 such pairs.

In how many assignment pairs does one range fully contain the other?

Your puzzle answer was ´518´.
###--- Part Two ---

It seems like there is still quite a bit of duplicate work planned. Instead, the Elves would like to know the number of pairs that overlap at all.

In the above example, the first two pairs `(2-4,6-8 and 2-3,4-5)` don't overlap, while the remaining four pairs `(5-7,7-9, 2-8,3-7, 6-6,4-6, and 2-6,4-8)` do overlap:

- `5-7,7-9` overlaps in a single section, ´7´.
- `2-8,3-7` overlaps all of the sections ´3´ through ´7´.
- `6-6,4-6` overlaps in a single section, ´6´.
- `2-6,4-8` overlaps in sections ´4´, ´5´, and ´6´.

So, in this example, the number of overlapping assignment pairs is ´4´.

In how many assignment pairs do the ranges overlap?

Your puzzle answer was ´909´.